### PR TITLE
Add command handler with arguments (like in python-telegram-bot)

### DIFF
--- a/samples/dispatcher/src/main/kotlin/me/ivmg/dispatcher/Main.kt
+++ b/samples/dispatcher/src/main/kotlin/me/ivmg/dispatcher/Main.kt
@@ -49,6 +49,12 @@ fun main(args: Array<String>) {
                 })
             }
 
+            command("commandWithArgs") { bot, update, args ->
+                val joinedArgs = args.joinToString()
+                val response = if (!joinedArgs.isNullOrBlank()) joinedArgs else "There is no text apart from command!"
+                bot.sendMessage(chatId = update.message!!.chat.id, text = response)
+            }
+
             command("inlineButtons") { bot, update ->
                 val chatId = update.message?.chat?.id ?: return@command
 

--- a/telegram/src/main/kotlin/me/ivmg/telegram/Callbacks.kt
+++ b/telegram/src/main/kotlin/me/ivmg/telegram/Callbacks.kt
@@ -9,8 +9,8 @@ typealias HandleUpdate = (Bot, Update) -> Unit
 
 typealias HandleError = (Bot, TelegramError) -> Unit
 
+typealias CommandHandleUpdate = (Bot, Update, List<String>) -> Unit
+
 typealias ContactHandleUpdate = (Bot, Update, Contact) -> Unit
 
 typealias LocationHandleUpdate = (Bot, Update, Location) -> Unit
-
-typealias CommandHandleUpdate = (Bot, Update, List<String>) -> Unit

--- a/telegram/src/main/kotlin/me/ivmg/telegram/Callbacks.kt
+++ b/telegram/src/main/kotlin/me/ivmg/telegram/Callbacks.kt
@@ -12,3 +12,5 @@ typealias HandleError = (Bot, TelegramError) -> Unit
 typealias ContactHandleUpdate = (Bot, Update, Contact) -> Unit
 
 typealias LocationHandleUpdate = (Bot, Update, Location) -> Unit
+
+typealias CommandHandleUpdate = (Bot, Update, List<String>) -> Unit

--- a/telegram/src/main/kotlin/me/ivmg/telegram/dispatcher/Dispatcher.kt
+++ b/telegram/src/main/kotlin/me/ivmg/telegram/dispatcher/Dispatcher.kt
@@ -1,10 +1,6 @@
 package me.ivmg.telegram.dispatcher
 
-import me.ivmg.telegram.Bot
-import me.ivmg.telegram.ContactHandleUpdate
-import me.ivmg.telegram.HandleError
-import me.ivmg.telegram.HandleUpdate
-import me.ivmg.telegram.LocationHandleUpdate
+import me.ivmg.telegram.*
 import me.ivmg.telegram.dispatcher.handlers.CallbackQueryHandler
 import me.ivmg.telegram.dispatcher.handlers.CommandHandler
 import me.ivmg.telegram.dispatcher.handlers.ContactHandler
@@ -18,6 +14,10 @@ import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
 
 fun Dispatcher.command(command: String, body: HandleUpdate) {
+    addHandler(CommandHandler(command, body))
+}
+
+fun Dispatcher.command(command: String, body: CommandHandleUpdate) {
     addHandler(CommandHandler(command, body))
 }
 

--- a/telegram/src/main/kotlin/me/ivmg/telegram/dispatcher/Dispatcher.kt
+++ b/telegram/src/main/kotlin/me/ivmg/telegram/dispatcher/Dispatcher.kt
@@ -1,6 +1,11 @@
 package me.ivmg.telegram.dispatcher
 
-import me.ivmg.telegram.*
+import me.ivmg.telegram.Bot
+import me.ivmg.telegram.ContactHandleUpdate
+import me.ivmg.telegram.HandleError
+import me.ivmg.telegram.HandleUpdate
+import me.ivmg.telegram.LocationHandleUpdate
+import me.ivmg.telegram.CommandHandleUpdate
 import me.ivmg.telegram.dispatcher.handlers.CallbackQueryHandler
 import me.ivmg.telegram.dispatcher.handlers.CommandHandler
 import me.ivmg.telegram.dispatcher.handlers.ContactHandler

--- a/telegram/src/main/kotlin/me/ivmg/telegram/dispatcher/handlers/CommandHandler.kt
+++ b/telegram/src/main/kotlin/me/ivmg/telegram/dispatcher/handlers/CommandHandler.kt
@@ -1,13 +1,24 @@
 package me.ivmg.telegram.dispatcher.handlers
 
+import me.ivmg.telegram.Bot
+import me.ivmg.telegram.CommandHandleUpdate
 import me.ivmg.telegram.HandleUpdate
 import me.ivmg.telegram.entities.Update
 
 class CommandHandler(private val command: String, handler: HandleUpdate) : Handler(handler) {
+
+    constructor(command: String, handler: CommandHandleUpdate) : this(command, CommandHandleUpdateProxy(handler))
+
     override val groupIdentifier: String = "CommandHandler"
 
     override fun checkUpdate(update: Update): Boolean {
         return (update.message?.text != null && update.message.text.startsWith("/") &&
             update.message.text.drop(1).split(" ")[0].split("@")[0] == command)
+    }
+}
+
+private class CommandHandleUpdateProxy(private val handleUpdate: CommandHandleUpdate) : HandleUpdate {
+    override fun invoke(bot: Bot, update: Update) {
+        handleUpdate(bot, update, update.message?.text?.split("\\s+".toRegex())?.drop(1) ?: listOf())
     }
 }


### PR DESCRIPTION
Added command handler that receives the message's text as a list of arguments, like in python-telegram-bot.  Also kept the old behavior.