### PR TITLE
Add filters for messages (#18)

### DIFF
--- a/samples/dispatcher/src/main/kotlin/me/ivmg/dispatcher/Main.kt
+++ b/samples/dispatcher/src/main/kotlin/me/ivmg/dispatcher/Main.kt
@@ -9,6 +9,7 @@ import me.ivmg.telegram.dispatcher.command
 import me.ivmg.telegram.dispatcher.contact
 import me.ivmg.telegram.dispatcher.handlers.CallbackQueryHandler
 import me.ivmg.telegram.dispatcher.location
+import me.ivmg.telegram.dispatcher.message
 import me.ivmg.telegram.dispatcher.telegramError
 import me.ivmg.telegram.dispatcher.text
 import me.ivmg.telegram.entities.InlineKeyboardButton
@@ -16,6 +17,7 @@ import me.ivmg.telegram.entities.InlineKeyboardMarkup
 import me.ivmg.telegram.entities.KeyboardButton
 import me.ivmg.telegram.entities.KeyboardReplyMarkup
 import me.ivmg.telegram.entities.ReplyKeyboardRemove
+import me.ivmg.telegram.extensions.filters.Filter
 import me.ivmg.telegram.network.fold
 import okhttp3.logging.HttpLoggingInterceptor
 
@@ -28,6 +30,14 @@ fun main(args: Array<String>) {
         logLevel = HttpLoggingInterceptor.Level.BODY
 
         dispatch {
+            message(Filter.Sticker) { bot, update ->
+                bot.sendMessage(update.message!!.chat.id, text = "You have received an awesome sticker \\o/")
+            }
+
+            message(Filter.Reply or Filter.Forward) { bot, update ->
+                bot.sendMessage(update.message!!.chat.id, text = "someone is replying or forwarding messages ...")
+            }
+
             command("start") { bot, update ->
 
                 val result = bot.sendMessage(chatId = update.message!!.chat.id, text = "Bot started")

--- a/telegram/build.gradle
+++ b/telegram/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     ext.kotlin_version = '1.2.50'
 
     ext.retrofit_version = '2.3.0'
+    ext.junit_version = "5.5.1"
     ext.logging_interceptor_version = '3.9.1'
 
     repositories {
@@ -31,8 +32,10 @@ dependencies {
     compile "com.squareup.okhttp3:logging-interceptor:$logging_interceptor_version"
 
     // Testing
-    testCompile "junit:junit:4.12"
-    testCompile "org.mockito:mockito-core:2.15.0"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:$junit_version"
+    testImplementation "io.mockk:mockk:1.9.3.kotlin12"
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/telegram/src/main/kotlin/me/ivmg/telegram/dispatcher/Dispatcher.kt
+++ b/telegram/src/main/kotlin/me/ivmg/telegram/dispatcher/Dispatcher.kt
@@ -13,12 +13,18 @@ import me.ivmg.telegram.dispatcher.handlers.CommandHandler
 import me.ivmg.telegram.dispatcher.handlers.ContactHandler
 import me.ivmg.telegram.dispatcher.handlers.Handler
 import me.ivmg.telegram.dispatcher.handlers.LocationHandler
+import me.ivmg.telegram.dispatcher.handlers.MessageHandler
 import me.ivmg.telegram.dispatcher.handlers.TextHandler
 import me.ivmg.telegram.entities.Update
 import me.ivmg.telegram.errors.TelegramError
+import me.ivmg.telegram.extensions.filters.Filter
 import me.ivmg.telegram.types.DispatchableObject
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
+
+fun Dispatcher.message(filter: Filter, handleUpdate: HandleUpdate) {
+    addHandler(MessageHandler(handleUpdate, filter))
+}
 
 fun Dispatcher.command(command: String, body: HandleUpdate) {
     addHandler(CommandHandler(command, body))

--- a/telegram/src/main/kotlin/me/ivmg/telegram/dispatcher/handlers/CheckoutHandler.kt
+++ b/telegram/src/main/kotlin/me/ivmg/telegram/dispatcher/handlers/CheckoutHandler.kt
@@ -3,15 +3,6 @@ package me.ivmg.telegram.dispatcher.handlers
 import me.ivmg.telegram.HandleUpdate
 import me.ivmg.telegram.entities.Update
 
-class InvoiceHandler(handleUpdate: HandleUpdate) : Handler(handleUpdate) {
-    override val groupIdentifier: String
-        get() = "payment"
-
-    override fun checkUpdate(update: Update): Boolean {
-        return update.message != null
-    }
-}
-
 class CheckoutHandler(handleUpdate: HandleUpdate) : Handler(handleUpdate) {
     override val groupIdentifier: String
         get() = "payment"

--- a/telegram/src/main/kotlin/me/ivmg/telegram/dispatcher/handlers/MessageHandler.kt
+++ b/telegram/src/main/kotlin/me/ivmg/telegram/dispatcher/handlers/MessageHandler.kt
@@ -1,0 +1,21 @@
+package me.ivmg.telegram.dispatcher.handlers
+
+import me.ivmg.telegram.HandleUpdate
+import me.ivmg.telegram.entities.Update
+import me.ivmg.telegram.extensions.filters.Filter
+
+class MessageHandler(
+    handlerCallback: HandleUpdate,
+    private val filter: Filter
+) : Handler(handlerCallback) {
+
+    override val groupIdentifier: String
+        get() = "MessageHandler"
+
+    override fun checkUpdate(update: Update): Boolean =
+        if (update.message == null) {
+            false
+        } else {
+            filter.checkFor(update.message)
+        }
+}

--- a/telegram/src/main/kotlin/me/ivmg/telegram/extensions/filters/Filters.kt
+++ b/telegram/src/main/kotlin/me/ivmg/telegram/extensions/filters/Filters.kt
@@ -1,0 +1,99 @@
+package me.ivmg.telegram.extensions.filters
+
+import me.ivmg.telegram.entities.Message
+
+interface Filter {
+    fun checkFor(message: Message): Boolean = message.predicate()
+    fun Message.predicate(): Boolean
+
+    infix fun and(otherFilter: Filter): Filter = object : Filter {
+        override fun Message.predicate(): Boolean =
+            this@Filter.checkFor(this) && otherFilter.checkFor(this)
+    }
+
+    infix fun or(otherFilter: Filter): Filter = object : Filter {
+        override fun Message.predicate(): Boolean =
+            this@Filter.checkFor(this) || otherFilter.checkFor(this)
+    }
+
+    operator fun not(): Filter = object : Filter {
+        override fun Message.predicate(): Boolean = !this@Filter.checkFor(this)
+    }
+
+    class Custom(private val customPredicate: Message.() -> Boolean): Filter {
+        override fun Message.predicate(): Boolean = customPredicate()
+    }
+
+    object All : Filter {
+        override fun Message.predicate(): Boolean = true
+    }
+
+    object Text : Filter {
+        override fun Message.predicate(): Boolean = text != null && !text.startsWith("/")
+    }
+
+    object Command : Filter {
+        override fun Message.predicate(): Boolean = text != null && text.startsWith("/")
+    }
+
+    object Reply : Filter {
+        override fun Message.predicate(): Boolean = replyToMessage != null
+    }
+
+    object Forward : Filter {
+        override fun Message.predicate(): Boolean = forwardDate != null
+    }
+
+    object Audio : Filter {
+        override fun Message.predicate(): Boolean = audio != null
+    }
+
+    object Photo : Filter {
+        override fun Message.predicate(): Boolean = photo != null && photo.isNotEmpty()
+    }
+
+    object Sticker : Filter {
+        override fun Message.predicate(): Boolean = sticker != null
+    }
+
+    object Video : Filter {
+        override fun Message.predicate(): Boolean = video != null
+    }
+
+    object VideoNote : Filter {
+        override fun Message.predicate(): Boolean = videoNote != null
+    }
+
+    object Location : Filter {
+        override fun Message.predicate(): Boolean = location != null
+    }
+
+    object Contact : Filter {
+        override fun Message.predicate(): Boolean = contact != null
+    }
+
+    object Invoice : Filter {
+        override fun Message.predicate(): Boolean = invoice != null
+    }
+
+    class Chat(private val chatId: Long) : Filter {
+        override fun Message.predicate(): Boolean = chat.id == chatId
+    }
+
+    class User(private val userId: Long) : Filter {
+        override fun Message.predicate(): Boolean = from?.id == userId
+    }
+
+    object Group : Filter {
+        override fun Message.predicate(): Boolean =
+            chat.type == "group" || chat.type == "supergroup"
+    }
+
+    object Private : Filter {
+        override fun Message.predicate(): Boolean = chat.type == "private"
+    }
+
+    object Channel : Filter {
+        override fun Message.predicate(): Boolean = chat.type == "channel"
+    }
+}

--- a/telegram/src/test/kotlin/BotTest.kt
+++ b/telegram/src/test/kotlin/BotTest.kt
@@ -1,5 +1,4 @@
-
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class BotTest {
 

--- a/telegram/src/test/kotlin/DispatcherTest.kt
+++ b/telegram/src/test/kotlin/DispatcherTest.kt
@@ -1,4 +1,4 @@
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class DispatcherTest {
 

--- a/telegram/src/test/kotlin/Mothers.kt
+++ b/telegram/src/test/kotlin/Mothers.kt
@@ -1,0 +1,305 @@
+import me.ivmg.telegram.entities.Audio
+import me.ivmg.telegram.entities.CallbackQuery
+import me.ivmg.telegram.entities.Chat
+import me.ivmg.telegram.entities.ChatPhoto
+import me.ivmg.telegram.entities.Contact
+import me.ivmg.telegram.entities.Document
+import me.ivmg.telegram.entities.Game
+import me.ivmg.telegram.entities.Invoice
+import me.ivmg.telegram.entities.Location
+import me.ivmg.telegram.entities.Message
+import me.ivmg.telegram.entities.MessageEntity
+import me.ivmg.telegram.entities.PhotoSize
+import me.ivmg.telegram.entities.Sticker
+import me.ivmg.telegram.entities.Update
+import me.ivmg.telegram.entities.User
+import me.ivmg.telegram.entities.Venue
+import me.ivmg.telegram.entities.Video
+import me.ivmg.telegram.entities.VideoNote
+import me.ivmg.telegram.entities.Voice
+import me.ivmg.telegram.entities.payment.PreCheckoutQuery
+import me.ivmg.telegram.entities.payment.ShippingQuery
+import me.ivmg.telegram.entities.payment.SuccessfulPayment
+
+private const val ANY_UPDATE_ID = 3523523L
+
+fun anyUpdate(
+    updateId: Long = ANY_UPDATE_ID,
+    message: Message? = null,
+    editedMessage: Message? = null,
+    channelPost: Message? = null,
+    editedChannelPost: Message? = null,
+    callbackQuery: CallbackQuery? = null,
+    preCheckoutQuery: PreCheckoutQuery? = null,
+    shippingQuery: ShippingQuery? = null
+): Update = Update(
+    updateId = updateId,
+    message = message,
+    editedMessage = editedMessage,
+    channelPost = channelPost,
+    editedChannelPost = editedChannelPost,
+    callbackQuery = callbackQuery,
+    preCheckoutQuery = preCheckoutQuery,
+    shippingQuery = shippingQuery
+)
+
+private const val ANY_MESSAGE_ID = 32142353L
+private const val ANY_DATE = 12412421
+
+fun anyMessage(
+    messageId: Long = ANY_MESSAGE_ID,
+    from: User? = null,
+    date: Int = ANY_DATE,
+    chat: Chat = anyChat(),
+    forwardFrom: User? = null,
+    forwardFromChat: Chat? = null,
+    forwardDate: Int? = null,
+    replyToMessage: Message? = null,
+    editDate: Int? = null,
+    text: String? = null,
+    entities: List<MessageEntity>? = null,
+    captionEntities: List<MessageEntity>? = null,
+    audio: Audio? = null,
+    document: Document? = null,
+    game: Game? = null,
+    photo: List<PhotoSize>? = null,
+    sticker: Sticker? = null,
+    video: Video? = null,
+    voice: Voice? = null,
+    videoNote: VideoNote? = null,
+    caption: String? = null,
+    contact: Contact? = null,
+    location: Location? = null,
+    venue: Venue? = null,
+    newChatMember: User? = null,
+    leftChatMember: User? = null,
+    newChatTitle: String? = null,
+    newChatPhoto: List<PhotoSize>? = null,
+    deleteChatPhoto: Boolean? = null,
+    groupChatCreated: Boolean? = null,
+    supergroupChatCreated: Boolean? = null,
+    channelChatCreated: Boolean? = null,
+    migrateToChatId: Long? = null,
+    migrateFromChatId: Long? = null,
+    invoice: Invoice? = null,
+    successfulPayment: SuccessfulPayment? = null
+): Message = Message(
+    messageId = messageId,
+    from = from,
+    date = date,
+    chat = chat,
+    forwardFrom = forwardFrom,
+    forwardFromChat = forwardFromChat,
+    forwardDate = forwardDate,
+    replyToMessage = replyToMessage,
+    editDate = editDate,
+    text = text,
+    entities = entities,
+    captionEntities = captionEntities,
+    audio = audio,
+    document = document,
+    game = game,
+    photo = photo,
+    sticker = sticker,
+    video = video,
+    voice = voice,
+    videoNote = videoNote,
+    caption = caption,
+    contact = contact,
+    location = location,
+    venue = venue,
+    newChatMember = newChatMember,
+    leftChatMember = leftChatMember,
+    newChatTitle = newChatTitle,
+    newChatPhoto = newChatPhoto,
+    deleteChatPhoto = deleteChatPhoto,
+    groupChatCreated = groupChatCreated,
+    supergroupChatCreated = supergroupChatCreated,
+    channelChatCreated = channelChatCreated,
+    migrateToChatId = migrateToChatId,
+    migrateFromChatId = migrateFromChatId,
+    invoice = invoice,
+    successfulPayment = successfulPayment
+)
+
+private const val ANY_CHAT_ID = 243423535L
+private const val ANY_CHAT_TYPE = "private"
+
+fun anyChat(
+    id: Long = ANY_CHAT_ID,
+    type: String = ANY_CHAT_TYPE,
+    title: String? = null,
+    username: String? = null,
+    firstName: String? = null,
+    lastName: String? = null,
+    allMembersAreAdministrators: Boolean? = null,
+    photo: ChatPhoto? = null,
+    description: String? = null,
+    inviteLink: String? = null,
+    pinnedMessage: String? = null,
+    stickerSetName: String? = null,
+    canSetStickerSet: Boolean? = null
+): Chat = Chat(
+    id = id,
+    type = type,
+    title = title,
+    username = username,
+    firstName = firstName,
+    lastName = lastName,
+    allMembersAreAdministrators = allMembersAreAdministrators,
+    photo = photo,
+    description = description,
+    inviteLink = inviteLink,
+    pinnedMessage = pinnedMessage,
+    stickerSetName = stickerSetName,
+    canSetStickerSet = canSetStickerSet
+)
+
+private const val ANY_FILE_ID = "fileId:353432q213412sd"
+private const val ANY_DURATION = 2421432
+
+fun anyAudio(
+    fileId: String = ANY_FILE_ID,
+    duration: Int = ANY_DURATION,
+    performer: String? = null,
+    title: String? = null,
+    mimeType: String? = null,
+    fileSize: Int? = null
+): Audio = Audio(
+    fileId = fileId,
+    duration = duration,
+    performer = performer,
+    title = title,
+    mimeType = mimeType,
+    fileSize = fileSize
+)
+
+private const val ANY_WIDTH = 23452345
+private const val ANY_HEIGHT = 674654
+
+fun anyPhotoSize(
+    fileId: String = ANY_FILE_ID,
+    width: Int = ANY_WIDTH,
+    height: Int = ANY_HEIGHT,
+    fileSize: Int? = null
+): PhotoSize = PhotoSize(
+    fileId = fileId,
+    width = width,
+    height = height,
+    fileSize = fileSize
+)
+
+fun anySticker(
+    fileId: String = ANY_FILE_ID,
+    width: Int = ANY_WIDTH,
+    height: Int = ANY_HEIGHT,
+    thumb: PhotoSize? = null,
+    emoji: String? = null,
+    fileSize: Int? = null
+): Sticker = Sticker(
+    fileId = fileId,
+    width = width,
+    height = height,
+    thumb = thumb,
+    emoji = emoji,
+    fileSize = fileSize
+)
+
+fun anyVideo(
+    fileId: String = ANY_FILE_ID,
+    width: Int = ANY_WIDTH,
+    height: Int = ANY_HEIGHT,
+    thumb: PhotoSize? = null,
+    mimeType: String? = null,
+    fileSize: Int? = null,
+    duration: Int = ANY_DURATION
+): Video = Video(
+    fileId = fileId,
+    width = width,
+    height = height,
+    thumb = thumb,
+    mimeType = mimeType,
+    fileSize = fileSize,
+    duration = duration
+)
+
+private const val ANY_LENGTH = 234234
+
+fun anyVideoNote(
+    fileId: String = ANY_FILE_ID,
+    thumb: PhotoSize? = null,
+    fileSize: Int? = null,
+    duration: Int = ANY_DURATION,
+    length: Int = ANY_LENGTH
+): VideoNote = VideoNote(
+    fileId = fileId,
+    thumb = thumb,
+    fileSize = fileSize,
+    duration = duration,
+    length = length
+)
+
+private const val ANY_LONGITUDE = 3.2235423F
+private const val ANY_LATITUDE = 32.1242F
+
+fun anyLocation(
+    longitude: Float = ANY_LONGITUDE,
+    latitude: Float = ANY_LATITUDE
+): Location = Location(
+    longitude = longitude,
+    latitude = latitude
+)
+
+private const val ANY_PHONE_NUMBER = "+346878344312"
+private const val ANY_FIRST_NAME = "rukeitor"
+
+fun anyContact(
+    phoneNumber: String = ANY_PHONE_NUMBER,
+    firstName: String = ANY_FIRST_NAME,
+    lastName: String? = null,
+    userId: Long? = null
+): Contact = Contact(
+    phoneNumber = phoneNumber,
+    firstName = firstName,
+    lastName = lastName,
+    userId = userId
+)
+
+private const val ANY_TITLE = "invoiceando"
+private const val ANY_DESCRIPTION = "describiendo"
+private const val ANY_START_PARAMETER = "ruka"
+private const val ANY_CURRENCY = "€"
+private const val ANY_TOTAL_AMOUNT = 666
+
+fun anyInvoice(
+    title: String = ANY_TITLE,
+    description: String = ANY_DESCRIPTION,
+    startParameter: String = ANY_START_PARAMETER,
+    currency: String = ANY_CURRENCY,
+    totalAmount: Int = ANY_TOTAL_AMOUNT
+): Invoice = Invoice(
+    title = title,
+    description = description,
+    startParameter = startParameter,
+    currency = currency,
+    totalAmount = totalAmount
+)
+
+private const val ANY_USER_ID = 325235L
+private const val IS_BOT = true
+
+fun anyUser(
+    userId: Long = ANY_USER_ID,
+    isBot: Boolean = IS_BOT,
+    firstName: String = ANY_FIRST_NAME,
+    lastName: String? = null,
+    username: String? = null,
+    languageCode: String? = null
+): User = User(
+    id = userId,
+    isBot = isBot,
+    firstName = firstName,
+    lastName = lastName,
+    username = username,
+    languageCode = languageCode
+)

--- a/telegram/src/test/kotlin/me/ivmg/telegram/dispatcher/handlers/MessageHandlerTest.kt
+++ b/telegram/src/test/kotlin/me/ivmg/telegram/dispatcher/handlers/MessageHandlerTest.kt
@@ -1,0 +1,51 @@
+package me.ivmg.telegram.dispatcher.handlers
+
+import anyMessage
+import anyUpdate
+import io.mockk.every
+import io.mockk.mockk
+import me.ivmg.telegram.HandleUpdate
+import me.ivmg.telegram.extensions.filters.Filter
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MessageHandlerTest {
+
+    private val handlerCallbackMock = mockk<HandleUpdate>()
+    private val filterMock = mockk<Filter>()
+
+    private val sut = MessageHandler(
+        handlerCallback = handlerCallbackMock,
+        filter = filterMock
+    )
+
+    @Test
+    fun `checkUpdate returns false when the update doesn't contain a message`() {
+        val checkUpdateResult = sut.checkUpdate(anyUpdate(message = null))
+
+        assertFalse(checkUpdateResult)
+    }
+
+    @Test
+    fun `checkUpdate returns true when the update contains a message and filter returns true`() {
+        givenFilterReturns(true)
+
+        val checkUpdateResult = sut.checkUpdate(anyUpdate(message = anyMessage()))
+
+        assertTrue(checkUpdateResult)
+    }
+
+    @Test
+    fun `checkUpdate returns false when the update contains a message and filter returns false`() {
+        givenFilterReturns(false)
+
+        val checkUpdateResult = sut.checkUpdate(anyUpdate(message = anyMessage()))
+
+        assertFalse(checkUpdateResult)
+    }
+
+    private fun givenFilterReturns(filterReturnValue: Boolean) {
+        every { filterMock.checkFor(any()) } returns filterReturnValue
+    }
+}

--- a/telegram/src/test/kotlin/me/ivmg/telegram/extensions/filters/FiltersTest.kt
+++ b/telegram/src/test/kotlin/me/ivmg/telegram/extensions/filters/FiltersTest.kt
@@ -1,0 +1,348 @@
+package me.ivmg.telegram.extensions.filters
+
+import anyAudio
+import anyChat
+import anyContact
+import anyInvoice
+import anyLocation
+import anyMessage
+import anyPhotoSize
+import anySticker
+import anyUser
+import anyVideo
+import anyVideoNote
+import me.ivmg.telegram.entities.Message
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+class FiltersTest {
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("provideFiltersTestCases")
+    fun `Test case - `(
+        @Suppress("UNUSED_PARAMETER") testCaseName: String,
+        filter: Filter,
+        message: Message,
+        expectedFilterResult: Boolean
+    ) {
+        val filterResult = filter.checkFor(message)
+
+        Assertions.assertEquals(expectedFilterResult, filterResult)
+    }
+
+    companion object {
+        @JvmStatic
+        fun provideFiltersTestCases(): Stream<Arguments> = Stream.of(
+            buildTestCase(
+                testCaseName = "AND function with all filters returning true returns true",
+                filter = anyFilterReturning(true)
+                        and anyFilterReturning(true)
+                        and anyFilterReturning(true),
+                message = anyMessage(),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "AND function with one filter returning false returns false",
+                filter = anyFilterReturning(false)
+                        and anyFilterReturning(true)
+                        and anyFilterReturning(true),
+                message = anyMessage(),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "OR function with one filter returning true returns true",
+                filter = anyFilterReturning(true)
+                        or anyFilterReturning(false)
+                        or anyFilterReturning(false),
+                message = anyMessage(),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "OR function with all filters returning false returns false",
+                filter = anyFilterReturning(false)
+                        or anyFilterReturning(false)
+                        or anyFilterReturning(false),
+                message = anyMessage(),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "NOT operator returns false for a filter returning true",
+                filter = !anyFilterReturning(true),
+                message = anyMessage(),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "NOT operator returns true for a filter returning false",
+                filter = !anyFilterReturning(false),
+                message = anyMessage(),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Custom returns true if the custom predicate returns true",
+                filter = Filter.Custom(customPredicate = { true }),
+                message = anyMessage(),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Custom returns false if the custom predicate returns false",
+                filter = Filter.Custom(customPredicate = { false }),
+                message = anyMessage(),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "Filter.All returns true for any message",
+                filter = Filter.All,
+                message = anyMessage(),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Text returns false for a non text message",
+                filter = Filter.Text,
+                message = anyMessage(text = null),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Text returns true for a non command text message",
+                filter = Filter.Text,
+                message = anyMessage(text = "Hello ruka world!!"),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Text returns false for a command text message",
+                filter = Filter.Text,
+                message = anyMessage(text = "/help"),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Command returns false for a non text message",
+                filter = Filter.Command,
+                message = anyMessage(text = null),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Command returns false for a non command text message",
+                filter = Filter.Command,
+                message = anyMessage(text = "Hello ruka world!!"),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Command returns true for a command text message",
+                filter = Filter.Command,
+                message = anyMessage(text = "/help"),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Reply returns false for a non reply message",
+                filter = Filter.Reply,
+                message = anyMessage(replyToMessage = null),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Reply returns true for a reply message",
+                filter = Filter.Reply,
+                message = anyMessage(replyToMessage = anyMessage()),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Forward returns false for a non forwarded message",
+                filter = Filter.Forward,
+                message = anyMessage(forwardDate = null),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Forward returns true for a forwarded message",
+                filter = Filter.Forward,
+                message = anyMessage(forwardDate = ANY_DATE),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Audio returns false for a non audio message",
+                filter = Filter.Audio,
+                message = anyMessage(audio = null),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Audio returns true for an audio message",
+                filter = Filter.Audio,
+                message = anyMessage(audio = anyAudio()),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Photo returns false for a non photo message",
+                filter = Filter.Photo,
+                message = anyMessage(photo = null),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Photo returns true for a photo message",
+                filter = Filter.Photo,
+                message = anyMessage(photo = listOf(anyPhotoSize())),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Sticker returns false for a non sticker message",
+                filter = Filter.Sticker,
+                message = anyMessage(sticker = null),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Sticker returns true for a sticker message",
+                filter = Filter.Sticker,
+                message = anyMessage(sticker = anySticker()),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Video returns false for a non video message",
+                filter = Filter.Video,
+                message = anyMessage(video = null),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Video returns true for a video message",
+                filter = Filter.Video,
+                message = anyMessage(video = anyVideo()),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "Filter.VideoNote returns false for a non video note message",
+                filter = Filter.VideoNote,
+                message = anyMessage(videoNote = null),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "Filter.VideoNote returns true for a video note message",
+                filter = Filter.VideoNote,
+                message = anyMessage(videoNote = anyVideoNote()),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Location returns false for a non location message",
+                filter = Filter.Location,
+                message = anyMessage(location = null),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Location returns true for a location message",
+                filter = Filter.Location,
+                message = anyMessage(location = anyLocation()),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Contact returns false for a non contact message",
+                filter = Filter.Contact,
+                message = anyMessage(contact = null),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Contact returns true for a contact message",
+                filter = Filter.Contact,
+                message = anyMessage(contact = anyContact()),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Invoice returns false for a non invoice message",
+                filter = Filter.Invoice,
+                message = anyMessage(invoice = null),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Invoice returns true for an invoice message",
+                filter = Filter.Invoice,
+                message = anyMessage(invoice = anyInvoice()),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Chat returns true if the message belongs to the indicated chat id",
+                filter = Filter.Chat(ANY_CHAT_ID),
+                message = anyMessage(chat = anyChat(id = ANY_CHAT_ID)),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Chat returns false if the message doesn't belong to the indicated chat id",
+                filter = Filter.Chat(ANY_CHAT_ID),
+                message = anyMessage(chat = anyChat(id = ANY_OTHER_CHAT_ID)),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "Filter.User returns true if the message was sent from the indicated user id",
+                filter = Filter.User(ANY_USER_ID),
+                message = anyMessage(from = anyUser(userId = ANY_USER_ID)),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "Filter.User returns false if the message wasn't sent from the indicated user id",
+                filter = Filter.User(ANY_USER_ID),
+                message = anyMessage(from = anyUser(userId = ANY_OTHER_USER_ID)),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "Filter.User returns false if there is no message sender",
+                filter = Filter.User(ANY_USER_ID),
+                message = anyMessage(from = null),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Private returns true if the chat type is 'private'",
+                filter = Filter.Private,
+                message = anyMessage(chat = anyChat(type = "private")),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Private returns false if the chat type is not 'private'",
+                filter = Filter.Private,
+                message = anyMessage(chat = anyChat(type = "group")),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Group returns true if the chat type is 'group'",
+                filter = Filter.Group,
+                message = anyMessage(chat = anyChat(type = "group")),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Group returns true if the chat type is 'supergroup'",
+                filter = Filter.Group,
+                message = anyMessage(chat = anyChat(type = "supergroup")),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Group returns false if the chat type is not 'group' or 'supergroup'",
+                filter = Filter.Group,
+                message = anyMessage(chat = anyChat(type = "private")),
+                expectedFilterResult = false
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Channel returns true if the chat type is 'channel'",
+                filter = Filter.Channel,
+                message = anyMessage(chat = anyChat(type = "channel")),
+                expectedFilterResult = true
+            ),
+            buildTestCase(
+                testCaseName = "Filter.Channel returns false if the chat type is not 'channel'",
+                filter = Filter.Channel,
+                message = anyMessage(chat = anyChat(type = "private")),
+                expectedFilterResult = false
+            )
+        )
+
+        private fun anyFilterReturning(valueToReturn: Boolean): Filter = object : Filter {
+            override fun Message.predicate(): Boolean = valueToReturn
+        }
+
+        private fun buildTestCase(
+            testCaseName: String,
+            filter: Filter,
+            message: Message,
+            expectedFilterResult: Boolean
+        ): Arguments = Arguments.of(testCaseName, filter, message, expectedFilterResult)
+
+        private const val ANY_DATE = 325232423
+        private const val ANY_CHAT_ID = 3523523L
+        private const val ANY_OTHER_CHAT_ID = 2213232L
+        private const val ANY_USER_ID = 235235235L
+        private const val ANY_OTHER_USER_ID = 7774575L
+    }
+}


### PR DESCRIPTION
As described on the issue #18 it would be really nice to have `Filters` for this library in the same way that _python-telegram-bot_ library do.

In this PR you'll see the changes needed to implement a first approach for having these kind of filters.

The main changes are the next:

1. A new `Handler` has been created for messages, called `MessageHandler`. This new handler can be built with a filter. It will run the handler callback function for every update with a message accepted by this filter.

2. An interface has been created for the filters (`Filter`) where all the provided filters and its operators are nested in. 

    It has a method called `checkFor` that receives a message as input parameter and returns true if the message matches the filter predicate. This method is used inside the `checkUpdate` method of the new `MessageHandler` to perform the update's filtering taking into account the provided message filter.

    A few functions have been added to this interface in order to combine or reverse filters (`and`, `or` and `not`).

    A bunch of filters have been implemented to provide built-in filters for different cases. Moreover, a `Custom` filter has been provided in order to allow library users to build their own filters.

3. A new extension function has been added to `Dispatcher` class to allow creating message handlers with filters in a Kotlin friendly way.

4. Regarding samples, two basic message handlers have been added to showcase the way of creating this kind of handlers with filters.

5. Regarding tests, a test suite has been added to cover all the created filters and its operators and a test suite has been created to cover the new `MessageHandler` too.