### PR TITLE
Add method to stop bot itself

### DIFF
--- a/telegram/src/main/kotlin/me/ivmg/telegram/Bot.kt
+++ b/telegram/src/main/kotlin/me/ivmg/telegram/Bot.kt
@@ -61,6 +61,8 @@ class Bot private constructor(
 
     fun startPolling() = updater.startPolling()
 
+    fun stopPolling() = updater.stopPolling()
+
     fun getUpdates(offset: Long): List<DispatchableObject> {
         val call = if (offset > 0)
             apiClient.getUpdates(offset = offset)

--- a/telegram/src/main/kotlin/me/ivmg/telegram/Updater.kt
+++ b/telegram/src/main/kotlin/me/ivmg/telegram/Updater.kt
@@ -8,17 +8,19 @@ import me.ivmg.telegram.entities.Update
 class Updater {
     private val executor: Executor = Executors.newCachedThreadPool()
     private var lastUpdateId = 0L
+    private var stopped = false
 
     lateinit var bot: Bot
     val dispatcher = Dispatcher()
 
     fun startPolling() {
+        stopped = false
         executor.execute { dispatcher.startCheckingUpdates() }
         executor.execute { updaterStartPolling() }
     }
 
     private fun updaterStartPolling() {
-        while (!Thread.currentThread().isInterrupted) {
+        while (!Thread.currentThread().isInterrupted && !stopped) {
             val items = bot.getUpdates(lastUpdateId)
 
             if (items.isEmpty()) continue
@@ -35,5 +37,10 @@ class Updater {
 
             lastUpdateId = lastUpdate.updateId + 1
         }
+    }
+
+    internal fun stopPolling() {
+        stopped = true
+        dispatcher.stopCheckingUpdates()
     }
 }

--- a/telegram/src/main/kotlin/me/ivmg/telegram/dispatcher/Dispatcher.kt
+++ b/telegram/src/main/kotlin/me/ivmg/telegram/dispatcher/Dispatcher.kt
@@ -74,13 +74,15 @@ class Dispatcher {
 
     private val commandHandlers = mutableMapOf<String, ArrayList<Handler>>()
     private val errorHandlers = arrayListOf<HandleError>()
+    private var stopped = false
 
     fun startCheckingUpdates() {
+        stopped = false
         checkQueueUpdates()
     }
 
     private fun checkQueueUpdates() {
-        while (!Thread.currentThread().isInterrupted) {
+        while (!Thread.currentThread().isInterrupted && !stopped) {
             val item = updatesQueue.take()
             if (item != null) {
                 if (item is Update) handleUpdate(item)
@@ -124,5 +126,9 @@ class Dispatcher {
         errorHandlers.forEach {
             it(bot, error)
         }
+    }
+
+    internal fun stopCheckingUpdates() {
+        stopped = true
     }
 }


### PR DESCRIPTION
Create a method to be able to stop the bot.
The same bot instance could be started after it is stoped.
It fixes #30 